### PR TITLE
Ft 52.1 cascada vista tienda, parrafos nosotros y ajustar desplegable navbar

### DIFF
--- a/src/front/js/component/navbar.js
+++ b/src/front/js/component/navbar.js
@@ -65,7 +65,7 @@ export const Navbar = () => {
                         {token ? (
                             <button
                                 type="button"
-                                className="btn btn-info ms-auto my-2 my-lg-0" 
+                                className="btn btn-info me-5 my-3 rounded text-white" 
                                 onClick={logout}
                             >
                                 <i className="fa-solid fa-right-from-bracket"></i> Cerrar sesión

--- a/src/front/js/component/navbar.js
+++ b/src/front/js/component/navbar.js
@@ -37,7 +37,7 @@ export const Navbar = () => {
                     >
                         <span className="navbar-toggler-icon"></span>
                     </button>
-                    <div className="collapse navbar-collapse" id="navbarSupportedContent">
+                    <div className="collapse navbar-collapse justify-content-end" id="navbarSupportedContent">
                         <ul className="navbar-nav mx-auto">
                             <li className="nav-item border-end">
                                 <a className="nav-link active" aria-current="page" href="/">Home</a>
@@ -65,7 +65,7 @@ export const Navbar = () => {
                         {token ? (
                             <button
                                 type="button"
-                                className="btn btn-info me-5 my-3 rounded text-white" 
+                                className="btn btn-info ms-auto my-2 my-lg-0" 
                                 onClick={logout}
                             >
                                 <i className="fa-solid fa-right-from-bracket"></i> Cerrar sesión

--- a/src/front/js/pages/nosotros.js
+++ b/src/front/js/pages/nosotros.js
@@ -16,8 +16,9 @@ export const Nosotros = () => {
             <p>¿Cansado de las grandes superficies y de la impersonalidad de las compras online? 
                 <br></br>En tu barrio queremos acercarte a los comercios de tu barrio, esos pequeños negocios llenos de encanto y
                 <br></br>productos únicos que hacen de nuestra comunidad un lugar especial.</p>
-
-            <h2>¿Qué te ofrece En tu barrio?</h2>
+                <br></br>
+                <br></br>
+            <h3>¿Qué te ofrece En tu barrio?</h3>
             <div className="lista-usuarios container px-5">
             <ul className="Lista-propuestas" style={{ textAlign: 'left' }}>
                 <li><strong>Un centro comercial virtual para tu barrio: </strong>
@@ -30,14 +31,18 @@ export const Nosotros = () => {
                 <li><strong>Precios competitivos: </strong>Compara precios y encuentra las mejores ofertas en productos de tus tiendas favoritas.</li>
             </ul>
             </div>
-            <h2>¿Eres un pequeño comerciante?</h2>
+            <br></br>
+            <br></br>
+            <h3>¿Eres un pequeño comerciante?</h3>
 
             <p>Únete a En tu barrio y da a conocer tu negocio a miles de clientes potenciales. <br></br>
             Crea tu perfil online de forma gratuita y empieza a vender tus productos desde hoy mismo.</p>
-
+            
+            
             <a href="/createuser"><h4>¡Regístrate ahora!</h4></a>
 
-            <h6>Juntos, podemos construir un futuro mejor para nuestros barrios.</h6>
+            <h6>Juntos, podemos construir un futuro mejor para nuestros barrios.</h6><br></br>
+            
             <a className="navbar-brand" href="/">
                         <img src={Logo} alt="Logo" className="logo-nos" />
                     </a>

--- a/src/front/js/pages/tienda.js
+++ b/src/front/js/pages/tienda.js
@@ -52,7 +52,7 @@ export const Tienda = () => {
                     <CategoriasProductos onCategoriaChange={handleCategoriaChange} id={params.id} />
                 </div>
             </div>
-            <div className="categorias-home-tienda grid-container">
+            <div className="grid-container-tienda">
                 {productosFiltrados.map((producto) => {
                     return (
                         <TodosProductos 

--- a/src/front/styles/navbar.css
+++ b/src/front/styles/navbar.css
@@ -30,4 +30,86 @@
     background-color: #f8f9fa;
 }
 
+.navbar-container {
+    height: 6em;
+    background-color: #f8f9fa;
+}
+
+.nav-link {
+    color: black;
+}
+
+.logo-nav {
+    width: 100px;  
+    height: auto;
+    margin-top: 1em;
+    margin-left: 2em;
+}
+
+.logo-letra {
+    width: 200px;  
+    height: auto;  
+}
+
+.titulo-navbar {
+    justify-self: center; 
+}
+
+.containerletra {
+    background-color: #f8f9fa;
+}
+
+.navbar-container {
+    height: 6em;
+    background-color: #f8f9fa;
+}
+
+.nav-link {
+    color: black;
+}
+
+.logo-nav {
+    width: 100px;  
+    height: auto;
+    margin-top: 1em;
+    margin-left: 2em;
+}
+
+.logo-letra {
+    width: 200px;  
+    height: auto;  
+}
+
+.titulo-navbar {
+    justify-self: center; 
+}
+
+.containerletra {
+    background-color: #f8f9fa;
+}
+
+/* Asegúrate de que los elementos del navbar se alineen correctamente */
+.navbar-nav {
+    display: flex;
+    flex-direction: column;
+    padding-left: 0;
+    margin-bottom: 0;
+    list-style: none;
+}
+
+.navbar-collapse {
+    justify-content: flex-end; /* Alinea el menú a la derecha */
+}
+
+/* Para dispositivos pequeños, aseguramos que el menú se alinee a la derecha */
+@media (max-width: 767.98px) {
+    .navbar-nav {
+        align-items: flex-end;
+        text-align: right;
+    }
+
+    .navbar-toggler {
+        margin-right: 1rem; /* Asegura que el botón esté alineado a la derecha con un pequeño margen */
+    }
+}
 

--- a/src/front/styles/navbar.css
+++ b/src/front/styles/navbar.css
@@ -88,7 +88,7 @@
     background-color: #f8f9fa;
 }
 
-/* Asegúrate de que los elementos del navbar se alineen correctamente */
+
 .navbar-nav {
     display: flex;
     flex-direction: column;
@@ -98,18 +98,30 @@
 }
 
 .navbar-collapse {
-    justify-content: flex-end; /* Alinea el menú a la derecha */
+    justify-content: flex-end; 
 }
 
-/* Para dispositivos pequeños, aseguramos que el menú se alinee a la derecha */
-@media (max-width: 767.98px) {
+/* //dispositivos pequeños// */
+
+@media (max-width: 800.98px) {
     .navbar-nav {
-        align-items: flex-end;
-        text-align: right;
+        align-items: flex-end; 
+        text-align: right; 
     }
 
     .navbar-toggler {
-        margin-right: 1rem; /* Asegura que el botón esté alineado a la derecha con un pequeño margen */
+        margin-right: 1rem; 
     }
+
+    .btn-info {
+    
+        margin-left: 90%; 
+        margin-right:1em ;
+    }
+        
+        
+   
 }
+
+
 

--- a/src/front/styles/tienda.css
+++ b/src/front/styles/tienda.css
@@ -98,3 +98,18 @@ justify-content: space-around;
     gap: 16px;
     padding: 16px;
 }
+
+
+.grid-container-tienda {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(1, 1fr); /* Por defecto, 1 columna */
+    justify-items: center;
+    align-items: start; /* Alinea los elementos al inicio verticalmente */
+}
+
+@media (min-width: 768px) {
+    .grid-container-tienda {
+        grid-template-columns: repeat(3, 1fr); /* A partir de 768px, 3 columnas */
+    }
+}

--- a/src/front/styles/tienda.css
+++ b/src/front/styles/tienda.css
@@ -81,20 +81,20 @@ justify-content: space-around;
   }
   
   .tienda-img {
-    width: 60%; /* Ancho completo */
-    max-width: 600px; /* Máximo ancho de 600px para que sea responsiva */
-    height: auto; /* Altura automática */
-    border-radius: 10px; /* Bordes redondeados */
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1); /* Sombra */
-    display: block; /* Para centrar la imagen */
-    margin: 20px auto; /* Margen superior e inferior de 20px y centrado horizontal */
-    border: 2px solid #ccc; /* Marco de 2px sólido de color gris */
+    width: 60%; 
+    max-width: 600px; 
+    height: auto; 
+    border-radius: 10px; 
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1); 
+    display: block; 
+    margin: 20px auto; 
+    border: 2px solid #ccc;
 }
 
 .categorias-home-tienda {
     display: flex;
-    flex-direction: column; /* Cambia la dirección del flex a columna */
-    align-items: center; /* Alinea los elementos en el centro */
+    flex-direction: column; 
+    align-items: center; 
     gap: 16px;
     padding: 16px;
 }
@@ -103,13 +103,13 @@ justify-content: space-around;
 .grid-container-tienda {
     display: grid;
     gap: 16px;
-    grid-template-columns: repeat(1, 1fr); /* Por defecto, 1 columna */
+    grid-template-columns: repeat(1, 1fr);
     justify-items: center;
-    align-items: start; /* Alinea los elementos al inicio verticalmente */
+    align-items: start; 
 }
 
 @media (min-width: 768px) {
     .grid-container-tienda {
-        grid-template-columns: repeat(3, 1fr); /* A partir de 768px, 3 columnas */
+        grid-template-columns: repeat(3, 1fr);
     }
 }


### PR DESCRIPTION
Vista tienda muestra 3 cards en vista de ordenador, y una en vista pequeña. Pequeños ajustes en el espaciado de los parrafos en nosotros y el desplegable del navbar está a la derecha, faltaría ajustar mejor el botón.
![Captura de Pantalla 2024-05-28 a las 10 50 01](https://github.com/4GeeksAcademy/proyecto-final-entubarrio/assets/147168257/ac789602-8430-4037-a25b-f1975a98e32d)
![Captura de Pantalla 2024-05-28 a las 10 50 44](https://github.com/4GeeksAcademy/proyecto-final-entubarrio/assets/147168257/127618a4-a490-43f6-9842-c680149d1c24)
![Captura de Pantalla 2024-05-28 a las 10 52 11](https://github.com/4GeeksAcademy/proyecto-final-entubarrio/assets/147168257/9395471b-d9cb-470b-afd5-ec0be9429ebf)
![Captura de Pantalla 2024-05-28 a las 11 04 08](https://github.com/4GeeksAcademy/proyecto-final-entubarrio/assets/147168257/a5014189-e0f7-4b18-aaf9-f100506c3b78)
